### PR TITLE
Add modifications developed by David Chen to CMakeLists.txt and

### DIFF
--- a/snplash/CMakeLists.txt
+++ b/snplash/CMakeLists.txt
@@ -1,8 +1,10 @@
 # CMakeLists.txt
 #
-# Created by Richard T. Guy <gu@cs.toronto.edu>
-# Modifications by David R. McWillams <dmcwilli@wakehealth.edu>
-#
+# Authored by: Richard T. Guy <gu@cs.toronto.edu>
+# Modified by: David R. McWillams <dmcwilli@wakehealth.edu>
+
+# Code for modules system created by David W. Chen, Wake Forest
+# University
 
 cmake_minimum_required(VERSION 2.4)
 
@@ -16,21 +18,34 @@ set(CMAKE_CXX_FLAGS "-O3 -fopenmp -g -Wall -Wunused")
 # chosen using the Intel 'Link Line Advisor v2.2' at
 # http://software.intel.com/en-us/articles/intel-mkl-link-line-advisor/
 
+### As of 2012-10-17
+# Intel Product: Intel(R) Composer XE 2011
+# OS: Linux
+# Compiler: Intel(R) C/C++
+# Architecture: Intel(R) 64
+# Dynamic or static linking: Dynamic
+# Interface layer: LP64 (32-bit integer)
+# Sequential or multi-threaded layer: Multi-threaded
+# OpenMP library: Intel(R) (libiomp5)
+# Cluster library: [NONE]
+# MPI library: [NONE]
+# Fortran 95 interfaces: [NONE]
+# Link with Intel MKL libraries explicitly: [UNCHECKED]
+
 if (ICPC)
     # set(CMAKE_CXX_FLAGS "-O3 -no-prec-div  -openmp -g -Wall -Wunused -wd981 -wd383 ")
-    set(LINKER_OPTS "-L$(MKLROOT)/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lm")
-    set(COMP_OPTS "-I$(MKLROOT)/include")
-    set(CMAKE_CXX_FLAGS "-O3 -no-prec-div -g Wall $COMP_OPTS $LINKER_OPTS")
+    set(COMP_OPTS "-I${MKLROOT}/include")
+    set(CMAKE_CXX_FLAGS "-xSSE4.2 -O3 -no-prec-div -openmp -mkl=parallel -g -Wall -Wunused -wd981 -wd383 ${COMP_OPTS}")
 endif (ICPC) 
 
-#SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/..)
+# SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/..)
 
 # The version number.
 set (SNPLASH_VERSION_MAJOR 1)
 set (SNPLASH_VERSION_MINOR 0)
 
-# configure a header file to pass some of the CMake settings
-# to the source code
+# Configure a header file to pass some of the CMake settings
+# to the source code.
 configure_file (
   "${PROJECT_SOURCE_DIR}/src/snplashConfig.h"
   "${PROJECT_BINARY_DIR}/src/snplashConfig.h"

--- a/snplash/buildForIntelCompiler
+++ b/snplash/buildForIntelCompiler
@@ -15,7 +15,8 @@
 mkdir build
 cd build
 
-module load openmpi/1.6-intel
+. /etc/profile.d/modules.sh
+module load compilers/intel-2012-lp64
 
 # The 'module load' command sets the compiler environment variable $MPICC.  Absent
 # the modules system, set the Intel compiler as in one of the examples below.
@@ -25,8 +26,8 @@ module load openmpi/1.6-intel
 # MPICC=`which mpicc`
 
 # And adjust the compiler command in the following if necessary.
-cmake -D CMAKE_CXX_COMPILER=$MPICC -D ICPC=TRUE ..
+cmake -D CMAKE_CXX_COMPILER=$CXX -D ICPC=TRUE ..
 
-echo "Now cd into ./build and type \'make\'. The executable will be in this directory."
+echo "Now cd into ./build and type 'make'. The executable will be in this directory."
 
 


### PR DESCRIPTION
buildForIntelCompiler to enable building for the Intel compiler under
the modules system.
